### PR TITLE
Added support for custom httpd dispatcher ports

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,29 @@
+- name: "Set default port facts"
+  set_fact:
+    _initial_port_suffix: ""
+    _expected_port_suffix: ""
+
+- name: "Set custom initial port suffix"
+  set_fact:
+    _initial_port_suffix: ":{{ conga_config.httpd.serverPort }}"
+    _expected_port_suffix: ":{{ conga_config.httpd.serverPort }}"
+  when:
+    - conga_config.httpd.serverPort != 80
+
+- name: "Set custom expected port suffix (http)"
+  set_fact:
+    _expected_port_suffix: ":{{ conga_config.httpd.serverPortSsl }}"
+  when:
+    - conga_config.httpd.serverPortSsl != 443
+    - conga_config.httpd.ssl.enforce
+
+- debug:
+    msg:
+      - _initial_port_suffix
+      - "{{ _initial_port_suffix }}"
+      - _expected_port_suffix
+      - "{{ _expected_port_suffix }}"
+
 - name: "Run aem-publish tests"
   static: no
   include: aem-publish-tests.yml

--- a/tasks/response-test.yml
+++ b/tasks/response-test.yml
@@ -1,11 +1,11 @@
 - name: "Set default (non-ssl) facts"
   set_fact:
-    _response_test_initial_url: "http://{{ response_test_config.httpd.serverName }}"
-    _reponse_test_expected_result_url: "http://{{ response_test_config.httpd.serverName }}/"
+    _response_test_initial_url: "http://{{ response_test_config.httpd.serverName }}{{ _initial_port_suffix }}"
+    _reponse_test_expected_result_url: "http://{{ response_test_config.httpd.serverName }}{{ _expected_port_suffix }}/"
 
 - name: "Set ssl facts"
   set_fact:
-    _reponse_test_expected_result_url: "https://{{ response_test_config.httpd.serverNameSsl }}/"
+    _reponse_test_expected_result_url: "https://{{ response_test_config.httpd.serverNameSsl }}{{ _expected_port_suffix }}/"
   when: response_test_config.httpd.ssl.enforce
 
 - debug:

--- a/tasks/ssl-enforce-test.yml
+++ b/tasks/ssl-enforce-test.yml
@@ -1,7 +1,7 @@
 - name: "Run enforce ssl test for {{ enforce_ssl_config.httpd.serverName }}"
   include: curl.yml
   vars:
-    curl_url: "http://{{ enforce_ssl_config.httpd.serverName }}"
-    curl_expected_url: "https://{{ enforce_ssl_config.httpd.serverNameSsl }}/"
+    curl_url: "http://{{ enforce_ssl_config.httpd.serverName }}{{ _initial_port_suffix }}"
+    curl_expected_url: "https://{{ enforce_ssl_config.httpd.serverNameSsl }}{{ _expected_port_suffix }}/"
     curl_expected_url_test_lazy: "{{ conga_aemdst_ssl_enforce_lazy }}"
     curl_follow_redirects: "{{ conga_aemdst_ssl_enforce_follow_redirects }}"


### PR DESCRIPTION
This PR depends on:
* https://github.com/wcm-io-devops/conga-aem-plugin/pull/2
* https://github.com/wcm-io-devops/conga-aem-definitions/pull/32
* https://github.com/wcm-io-devops/ansible-aem-dispatcher/pull/2

and adds support for custom http and https ports.