### PR TITLE
Add support for curl resolve and SSL offloading scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ Maximum time allowed for the connection to the dispatcher in seconds.
 
 Maximum time allowed for the dispatcher smoke test operation in seconds.
 
-    conga_aemdst_curl_host: "{{ inventory_hostname }}"
+    # conga_aemdst_curl_host: "{{ inventory_hostname }}"
 
-Host from which the smoke tests are executed.
+Host from which the smoke tests are executed. Per default this is the
+ansible host.
 
     conga_aemdst_curl_resolve:
       - host: "{{ conga_aemdst_curl_url | urlsplit('hostname') }}"

--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ Maximum time allowed for the dispatcher smoke test operation in seconds.
 
 Host from which the smoke tests are executed.
 
+    conga_aemdst_curl_resolve:
+      - host: "{{ conga_aemdst_curl_url | urlsplit('hostname') }}"
+        port: "80"
+        address: "127.0.0.1"
+      - host: "{{ conga_aemdst_curl_url | urlsplit('hostname') }}"
+        port: "443"
+        address: "127.0.0.1"
+
+Allows to overwrite/control the host resolve mechanism of curl.
+
 ## Dependencies
 
 This role depends on the

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Maximum time allowed for the connection to the dispatcher in seconds.
 
 Maximum time allowed for the dispatcher smoke test operation in seconds.
 
-    # conga_aemdst_curl_host: "{{ inventory_hostname }}"
+    conga_aemdst_curl_host: "{{ inventory_hostname }}"
 
 Host from which the smoke tests are executed. Per default this is the
 ansible host.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,7 @@ conga_aemdst_curl_host: "{{ inventory_hostname }}"
 # conga_aemdst_curl_url
 # conga_aemdst_curl_expected_url
 
-# Per default we resolve the hostnames of the system to localhost
+# Allows to overwrite/control the host resolve mechanism of curl
 conga_aemdst_curl_resolve:
   - host: "{{ conga_aemdst_curl_url | urlsplit('hostname') }}"
     port: "80"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,7 +37,7 @@ conga_aemdst_curl_connect_timeout: 10
 conga_aemdst_curl_timeout: 60
 
 # Host from which the smoke tests are executed
-conga_aemdst_curl_host: "{{ inventory_hostname }}"
+# conga_aemdst_curl_host: "{{ inventory_hostname }}"
 
 # Mandatory variables that have to be provided to the curl task
 # conga_aemdst_curl_url

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,3 +42,13 @@ conga_aemdst_curl_host: "{{ inventory_hostname }}"
 # Mandatory variables that have to be provided to the curl task
 # conga_aemdst_curl_url
 # conga_aemdst_curl_expected_url
+
+# Per default we resolve the hostnames of the system to localhost
+conga_aemdst_curl_resolve:
+  - host: "{{ conga_aemdst_curl_url | urlsplit('hostname') }}"
+    port: "80"
+    address: "127.0.0.1"
+  - host: "{{ conga_aemdst_curl_url | urlsplit('hostname') }}"
+    port: "443"
+    address: "127.0.0.1"
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,7 +37,7 @@ conga_aemdst_curl_connect_timeout: 10
 conga_aemdst_curl_timeout: 60
 
 # Host from which the smoke tests are executed
-# conga_aemdst_curl_host: "{{ inventory_hostname }}"
+conga_aemdst_curl_host: "{{ inventory_hostname }}"
 
 # Mandatory variables that have to be provided to the curl task
 # conga_aemdst_curl_url

--- a/tasks/aem-author-tests.yml
+++ b/tasks/aem-author-tests.yml
@@ -3,6 +3,9 @@
   vars:
     enforce_ssl_config: "{{ conga_config }}"
   when: conga_config.httpd.ssl.enforce
+  tags:
+    - conga-aemdst-ssl-enforce
+    - conga-aemdst-ssl-enforce-author
 
 - name: "Check for HTTP code 401 in final http(s) response"
   include_tasks: response-test.yml
@@ -11,3 +14,6 @@
     response_test_expected_http_code: "{{ conga_aemdst_author_expected_http_code }}"
     response_test_lazy: "{{ conga_aemdst_author_follow_redirects }}"
     response_test_follow_redirects: "{{ conga_aemdst_author_lazy }}"
+  tags:
+    - conga-aemdst-response
+    - conga-aemdst-response-author

--- a/tasks/aem-publish-tests.yml
+++ b/tasks/aem-publish-tests.yml
@@ -6,6 +6,9 @@
   with_items: "{{ conga_tenants }}"
   loop_control:
     loop_var: _tenant
+  tags:
+    - conga-aemdst-ssl-enforce
+    - conga-aemdst-ssl-enforce-publish
 
 - name: "Check for HTTP code 200 in final http(s) response"
   include_tasks: response-test.yml
@@ -17,3 +20,6 @@
   with_items: "{{ conga_tenants }}"
   loop_control:
     loop_var: _tenant
+  tags:
+    - conga-aemdst-response
+    - conga-aemdst-response-publish

--- a/tasks/curl.yml
+++ b/tasks/curl.yml
@@ -69,7 +69,7 @@
     --output /dev/null --silent \
     {{ conga_aemdst_curl_url }}'
   register: curl_result
-  delegate_to: "{{ conga_aemdst_curl_host | default(omit) }}"
+  delegate_to: "{{ conga_aemdst_curl_host }}"
   args:
     warn: false
   tags:

--- a/tasks/curl.yml
+++ b/tasks/curl.yml
@@ -49,29 +49,48 @@
     - "{{ conga_aemdst_curl_headers }}"
   when: conga_aemdst_curl_headers is defined
 
+- name: "Set base curl command."
+  set_fact:
+    _curl_base_command: >-
+      curl
+      {{ _insecure_arg }}
+      {{ _location_arg }}
+      {{ _noproxy_arg }}
+      {{ _resolve_arg }}
+      {{ _headers_arg }}
+      --max-time {{ conga_aemdst_curl_timeout }}
+      --connect-timeout {{ conga_aemdst_curl_connect_timeout }}
+
+- name: "{{ item }} : Set curl commands."
+  set_fact:
+    # command used internally only
+    _curl_internal_command: >-
+      {{ _curl_base_command }}
+      --write-out "{{ _write_out_arg }}"
+      --output /dev/null --silent
+      {{ conga_aemdst_curl_url }}
+    # command will be displayed to the user to ensure fast debugging
+    _curl_debug_command: >-
+      {{ _curl_base_command }}
+      {{ conga_aemdst_curl_url }}
+
 - debug:
     msg:
       - "check redirect from: {{ conga_aemdst_curl_url }}"
       - "check redirect to  : {{ conga_aemdst_curl_expected_url }}"
       - "check for http code: {{ _expected_http_code }}"
-      - "check with args    : {{ _insecure_arg }} {{ _location_arg }} {{ _resolve_arg }} {{ _headers_arg }}"
+      - "Internal curl command:"
+      - "{{ _curl_internal_command }}"
+      - "Debug curl command:"
+      - "{{ _curl_debug_command }}"
 
 - name: "Executing curl"
-  shell: 'curl \
-    {{ _insecure_arg }} \
-    {{ _location_arg }} \
-    {{ _noproxy_arg }} \
-    {{ _resolve_arg }} \
-    {{ _headers_arg }} \
-    --max-time {{ conga_aemdst_curl_timeout }} \
-    --connect-timeout {{ conga_aemdst_curl_connect_timeout }} \
-    --write-out "{{ _write_out_arg }}" \
-    --output /dev/null --silent \
-    {{ conga_aemdst_curl_url }}'
+  shell: "{{ _curl_internal_command }}"
   register: curl_result
   delegate_to: "{{ conga_aemdst_curl_host }}"
   args:
     warn: false
+  changed_when: false
   tags:
     - skip_ansible_lint
 
@@ -85,7 +104,7 @@
   assert:
     that:
       - "{{ conga_aemdst_curl_expected_url in _actual_url }}"
-    msg: >
+    msg: >-
       The actual url does not match with expected url (lazy)
       expected: {{ conga_aemdst_curl_expected_url }}
       actual  : {{ _actual_url }}
@@ -96,7 +115,7 @@
   assert:
     that:
       - "{{ conga_aemdst_curl_expected_url == _actual_url }}"
-    msg: >
+    msg: >-
       The actual url does not match with expected url (strict)
       expected: {{ conga_aemdst_curl_expected_url }}
       actual  : {{ _actual_url }}
@@ -106,7 +125,7 @@
   assert:
     that:
       - "{{ _expected_http_code }} == {{ _actual_http_code }}"
-    msg: >
+    msg: >-
       The actual http_code does not match with expected http_code
       expected: {{ _expected_http_code }}
       actual  : {{ _actual_http_code }}

--- a/tasks/curl.yml
+++ b/tasks/curl.yml
@@ -69,7 +69,7 @@
     --output /dev/null --silent \
     {{ conga_aemdst_curl_url }}'
   register: curl_result
-  delegate_to: "{{ conga_aemdst_curl_host }}"
+  delegate_to: "{{ conga_aemdst_curl_host | default(omit) }}"
   args:
     warn: false
   tags:

--- a/tasks/curl.yml
+++ b/tasks/curl.yml
@@ -14,6 +14,8 @@
     _location_arg: ""
     _insecure_arg: ""
     _noproxy_arg: ""
+    _resolve_arg: ""
+    _headers_arg: ""
     _expected_http_code: "{{ conga_aemdst_curl_expected_http_code }}"
 
 - name: "Set follow redirect facts"
@@ -33,18 +35,34 @@
     _noproxy_arg: '--noproxy "*"'
   when: conga_aemdst_curl_noproxy
 
+- name: "Add '--resolve'."
+  set_fact:
+    _resolve_arg: "{{ _resolve_arg }} --resolve '{{ item.host }}:{{ item.port }}:{{ item.address }}'"
+  with_items:
+    - "{{ conga_aemdst_curl_resolve }}"
+  when: conga_aemdst_curl_resolve is defined
+
+- name: "Add '--headers'."
+  set_fact:
+    _headers_arg: "{{ _headers_arg }} --header \"{{ item }}\""
+  with_items:
+    - "{{ conga_aemdst_curl_headers }}"
+  when: conga_aemdst_curl_headers is defined
+
 - debug:
     msg:
       - "check redirect from: {{ conga_aemdst_curl_url }}"
       - "check redirect to  : {{ conga_aemdst_curl_expected_url }}"
       - "check for http code: {{ _expected_http_code }}"
-      - "check with args    : {{ _insecure_arg }} {{ _location_arg }}"
+      - "check with args    : {{ _insecure_arg }} {{ _location_arg }} {{ _resolve_arg }}"
 
 - name: "Executing curl"
   shell: 'curl \
     {{ _insecure_arg }} \
     {{ _location_arg }} \
     {{ _noproxy_arg }} \
+    {{ _resolve_arg }} \
+    {{ _headers_arg }} \
     --max-time {{ conga_aemdst_curl_timeout }} \
     --connect-timeout {{ conga_aemdst_curl_connect_timeout }} \
     --write-out "{{ _write_out_arg }}" \
@@ -52,6 +70,8 @@
     {{ conga_aemdst_curl_url }}'
   register: curl_result
   delegate_to: "{{ conga_aemdst_curl_host }}"
+  args:
+    warn: false
   tags:
     - skip_ansible_lint
 

--- a/tasks/curl.yml
+++ b/tasks/curl.yml
@@ -54,7 +54,7 @@
       - "check redirect from: {{ conga_aemdst_curl_url }}"
       - "check redirect to  : {{ conga_aemdst_curl_expected_url }}"
       - "check for http code: {{ _expected_http_code }}"
-      - "check with args    : {{ _insecure_arg }} {{ _location_arg }} {{ _resolve_arg }}"
+      - "check with args    : {{ _insecure_arg }} {{ _location_arg }} {{ _resolve_arg }} {{ _headers_arg }}"
 
 - name: "Executing curl"
   shell: 'curl \

--- a/tasks/response-test.yml
+++ b/tasks/response-test.yml
@@ -1,25 +1,40 @@
 - name: "Set default (non-ssl) facts"
   set_fact:
     _response_test_initial_url: "http://{{ response_test_config.httpd.serverName }}{{ _initial_port_suffix }}"
-    _reponse_test_expected_result_url: "http://{{ response_test_config.httpd.serverName }}{{ _expected_port_suffix }}/"
+    _response_test_expected_result_url: "http://{{ response_test_config.httpd.serverName }}{{ _expected_port_suffix }}/"
+    _response_test_headers: []
 
-- name: "Set ssl facts"
+# When ssl is enforced and we have no ssl offloading we expect an upgrade to https during the response test.
+- name: "Set ssl facts."
   set_fact:
-    _reponse_test_expected_result_url:
+    _response_test_expected_result_url:
       "https://{{ response_test_config.httpd.serverNameSsl }}{{ _expected_port_suffix }}/"
-  when: response_test_config.httpd.ssl.enforce
+  when:
+    - response_test_config.httpd.ssl.enforce
+    - not response_test_config.httpd.ssl.offloading.enabled # when ssl is offloaded we are not expecting an https upgrade
+
+# When ssl is enforced but offloading is enabled we have to send the "X-Forwarded-Proto" header for the response test
+- name: "Set ssl-offloading facts."
+  set_fact:
+    _response_test_headers:
+      - 'X-Forwarded-Proto: https'
+  when:
+    - response_test_config.httpd.ssl.enforce
+    - response_test_config.httpd.ssl.offloading.enabled
 
 - debug:
     msg:
       - "_response_test_initial_url        : {{ _response_test_initial_url }}"
-      - "_reponse_test_expected_result_url : {{ _reponse_test_expected_result_url }}"
+      - "_response_test_expected_result_url : {{ _response_test_expected_result_url }}"
       - "response_test_expected_http_code  : {{ response_test_expected_http_code }}"
 
 - name: "Check for {{ aemdst_response_test_expected_http_code }} response when following redirects"
   include_tasks: curl.yml
   vars:
     conga_aemdst_curl_url: "{{ _response_test_initial_url }}"
-    conga_aemdst_curl_expected_url: "{{ _reponse_test_expected_result_url }}"
+    conga_aemdst_curl_expected_url: "{{ _response_test_expected_result_url }}"
     conga_aemdst_curl_expected_url_test_lazy: "{{ response_test_lazy }}"
     conga_aemdst_curl_follow_redirects_expected_http_code: "{{ response_test_expected_http_code }}"
     conga_aemdst_curl_follow_redirects: "{{ response_test_follow_redirects }}"
+    conga_aemdst_curl_headers: "{{ _response_test_headers }}"
+


### PR DESCRIPTION
* Add support to control the host resolve for curl (per default this is localhost)
* Add tags to allow task skipping
* Add support for X-Forwarded-Proto header when `response_test_config.httpd.ssl.offloading.enabled` is `true`
* Do not check for SSL upgrade in response test when `response_test_config.httpd.ssl.offloading.enabled` is `true`.
* Typo fixes