### PR TITLE
Use templating for URL pratterns; fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ a lazy match.
     conga_aemdst_response_test_expected_url_overrides: []
     # example:
     #  - pattern: http:\/\/company1\.tld\/
-    #    expected_url: https:\/\/sso.company1\.tld\/
+    #    expected_url: https://sso.company1.tld/
 
 Allows overriding of expected urls by matching the `pattern` against the
 automatic calculated expected url and overwriting it with the provided

--- a/action_plugins/conga_aemdst_facts.py
+++ b/action_plugins/conga_aemdst_facts.py
@@ -133,6 +133,7 @@ class ActionModule(ActionBase):
 
     def _get_arg_or_var(self, name, default=None, is_required=True):
         ret = self._task.args.get(name, self._task_vars.get(name, default))
+        ret = self._templar.template(ret)
         if is_required and not ret:
             raise AnsibleOptionsError("parameter %s is required" % name)
         else:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ conga_aemdst_ssl_enforce_follow_redirects: false
 conga_aemdst_response_test_expected_url_overrides: []
 # example:
 #  - pattern: http:\/\/company1\.tld\/
-#    expected_url: https:\/\/sso.company1\.tld\/
+#    expected_url: https://sso.company1.tld/
 
 
 # Default response code of the curl task


### PR DESCRIPTION
This change makes it possible to use Jinja templates for defining `conga_aemdst_response_test_expected_url_overrides`