### PR TITLE
Add means to override expected HTTP code in response test

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ a lazy match.
     # example:
     #  - pattern: http:\/\/company1\.tld\/
     #    expected_url: https://sso.company1.tld/
+    #    response_code: 401
 
 Allows overriding of expected urls by matching the `pattern` against the
 automatic calculated expected url and overwriting it with the provided
-`expected_url`.
+`expected_url`. You can also override the expected response code for specific URL patterns.
 
     conga_aemdst_curl_expected_http_code: 301
 

--- a/action_plugins/conga_aemdst_facts.py
+++ b/action_plugins/conga_aemdst_facts.py
@@ -106,9 +106,6 @@ class ActionModule(ActionBase):
                         display.v("pattern matched, replacing expected http code with %s" % http_code_override)
                         response_test_http_code_override = http_code_override
                     break
-                else:
-                    display.v("pattern not matched; pattern: %s, expected url: %s" % (pattern,
-                                                                                      response_test_expected_url))
 
         results = {
             # "config": config,

--- a/action_plugins/curl_cmdline_helper.py
+++ b/action_plugins/curl_cmdline_helper.py
@@ -44,6 +44,7 @@ class ActionModule(ActionBase):
             conga_aemdst_curl_headers = self._get_arg_or_var('conga_aemdst_curl_headers', [], False)
             conga_aemdst_curl_timeout = self._get_arg_or_var('conga_aemdst_curl_timeout')
             conga_aemdst_curl_connect_timeout = self._get_arg_or_var('conga_aemdst_curl_connect_timeout')
+            conga_aemdst_curl_response_test_http_code_override = self._get_arg_or_var('conga_aemdst_curl_response_test_http_code_override', None)
 
         except AnsibleOptionsError as err:
             return self._fail_result(result, err.message)
@@ -81,6 +82,9 @@ class ActionModule(ActionBase):
                                                                                             write_out_arg,
                                                                                             conga_aemdst_curl_url)
         curl_debug_command = "{} {}".format(curl_base_command, conga_aemdst_curl_url)
+
+        if conga_aemdst_curl_response_test_http_code_override:
+            expected_http_code = conga_aemdst_curl_response_test_http_code_override
 
         results = {
             "curl_base_command": curl_base_command,

--- a/tasks/response-test.yml
+++ b/tasks/response-test.yml
@@ -25,6 +25,7 @@
     conga_aemdst_curl_resolve_ip_ssl: "{{ conga_aemdst_config.server_listen_address_ssl }}"
     conga_aemdst_curl_expected_url: "{{ conga_aemdst_config.response_test_expected_url }}"
     conga_aemdst_curl_expected_url_test_lazy: "{{ response_test_lazy }}"
+    conga_aemdst_curl_response_test_http_code_override: "{{ conga_aemdst_config.response_test_http_code_override }}"
     conga_aemdst_curl_follow_redirects_expected_http_code: "{{ response_test_expected_http_code }}"
     conga_aemdst_curl_follow_redirects: "{{ response_test_follow_redirects }}"
     conga_aemdst_curl_headers: "{{ conga_aemdst_config.response_test_headers }}"

--- a/tasks/ssl-enforce-test.yml
+++ b/tasks/ssl-enforce-test.yml
@@ -16,6 +16,7 @@
     conga_aemdst_curl_server_port_ssl: "{{ conga_aemdst_config.listen_port_ssl }}"
     conga_aemdst_curl_expected_url: "{{ conga_aemdst_config.ssl_enforce_expected_url }}"
     conga_aemdst_curl_expected_url_test_lazy: "{{ conga_aemdst_ssl_enforce_lazy }}"
+    conga_aemdst_curl_response_test_http_code_override: "{{ conga_aemdst_config.response_test_http_code_override }}"
     conga_aemdst_curl_follow_redirects: "{{ conga_aemdst_ssl_enforce_follow_redirects }}"
     conga_aemdst_curl_resolve_ip: "{{ conga_aemdst_config.server_listen_address }}"
     conga_aemdst_curl_resolve_ip_ssl: "{{ conga_aemdst_config.server_listen_address_ssl }}"


### PR DESCRIPTION
For example if you have a tenant that is access restricted by default, you might want to override the expected response to 401.